### PR TITLE
Add line_id member for syscall and line_id generation in recording (2…

### DIFF
--- a/dataloader/recording.py
+++ b/dataloader/recording.py
@@ -53,8 +53,8 @@ class Recording:
         try:
             with zipfile.ZipFile(self.path, 'r') as zipped:
                 with zipped.open(self.name + '.sc') as unzipped:
-                    for syscall in unzipped:
-                        syscall_object = Syscall(syscall.decode('utf-8').rstrip())
+                    for line_id, syscall in enumerate(unzipped, start=1):
+                        syscall_object = Syscall(syscall.decode('utf-8').rstrip(), line_id=line_id)
                         if self._direction != Direction.BOTH:
                             if syscall_object.direction() == self._direction:
                                 yield syscall_object

--- a/dataloader/recording_2019.py
+++ b/dataloader/recording_2019.py
@@ -49,13 +49,13 @@ class Recording:
 
         """
         with open(self.path, 'r') as recording_file:
-            for syscall in recording_file:
-                syscall_object = Syscall(syscall)
+            for line_id, syscall in enumerate(recording_file, start=1):
+                syscall_object = Syscall(syscall, line_id=line_id)
                 if self._direction != Direction.BOTH:
                     if syscall_object.direction() == self._direction and syscall_object.name() != 'switch':
                         yield syscall_object
                 elif syscall_object.name() != 'switch':
-                    yield Syscall(syscall)
+                    yield Syscall(syscall, line_id=line_id)
 
     def _collect_metadata(self):
         """

--- a/dataloader/syscall.py
+++ b/dataloader/syscall.py
@@ -29,9 +29,10 @@ class Syscall:
 
     """
 
-    def __init__(self, syscall_line: str):
+    def __init__(self, syscall_line: str, line_id: int = -1):
         self.syscall_line = syscall_line
         self._line_list = syscall_line.split(' ')
+        self._line_id = line_id
         self._timestamp_unix = None
         self._timestamp_datetime = None
         self._user_id = None

--- a/dataloader/syscall_2019.py
+++ b/dataloader/syscall_2019.py
@@ -29,9 +29,10 @@ class Syscall:
     all attributes need to be retrieved by corresponding methods
     """
 
-    def __init__(self, syscall_line: str):
+    def __init__(self, syscall_line: str, line_id: int = -1):
         self.syscall_line = syscall_line.rstrip()
         self._line_list = self.syscall_line.split(' ')
+        self._line_id = line_id
         self._timestamp_unix = None
         self._timestamp_datetime = None
         self._user_id = None


### PR DESCRIPTION
…019 and 2021)

The syscall class gets a new member line_id and the optional parameter line_id which has the default value of -1.
In the recording class the syscalls method enumerates the lines starting with 1.
Could not test the changes for LID-DS 2021.