### PR TITLE
Fix metasploit docker

### DIFF
--- a/scenarios/Bruteforce_CWE-307/exploit/Dockerfile
+++ b/scenarios/Bruteforce_CWE-307/exploit/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt
 
 # Installation
 RUN apt-get -qq update \
-  && apt-get -yq install --no-install-recommends build-essential patch ruby-bundler ruby-dev zlib1g-dev liblzma-dev git autoconf build-essential libpcap-dev libpq-dev libsqlite3-dev \
+  && apt-get -yq install --no-install-recommends build-essential patch ruby-bundler ruby-dev zlib1g-dev liblzma-dev git autoconf build-essential libpcap-dev libpq-dev libsqlite3-dev python3-setuptools\
     postgresql postgresql-contrib postgresql-client \
     ruby python \
     dialog apt-utils \
@@ -25,8 +25,7 @@ RUN apt-get -qq update \
   && git clone https://github.com/rapid7/metasploit-framework.git \
   && cd metasploit-framework \
   && git fetch --tags \
-  && latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) \
-  && git checkout $latestTag \
+  && git checkout 6.1.5 \
   && rm Gemfile.lock \
   && bundle install \
   && /etc/init.d/postgresql start && su postgres -c "psql -f /tmp/db.sql" \

--- a/scenarios/CVE-2014-0160/exploit/Dockerfile
+++ b/scenarios/CVE-2014-0160/exploit/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt
 
 # Installation
 RUN apt-get -qq update \
-  && apt-get -yq install --no-install-recommends build-essential patch ruby-bundler ruby-dev zlib1g-dev liblzma-dev git autoconf build-essential libpcap-dev libpq-dev libsqlite3-dev \
+  && apt-get -yq install --no-install-recommends build-essential patch ruby-bundler ruby-dev zlib1g-dev liblzma-dev git autoconf build-essential libpcap-dev libpq-dev libsqlite3-dev python3-setuptools \
     postgresql postgresql-contrib postgresql-client \
     ruby python \
     dialog apt-utils \

--- a/scenarios/CVE-2014-0160/exploit/Dockerfile
+++ b/scenarios/CVE-2014-0160/exploit/Dockerfile
@@ -25,8 +25,7 @@ RUN apt-get -qq update \
   && git clone https://github.com/rapid7/metasploit-framework.git \
   && cd metasploit-framework \
   && git fetch --tags \
-  && latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) \
-  && git checkout $latestTag \
+  && git checkout 6.1.5 \
   && rm Gemfile.lock \
   && bundle install \
   && /etc/init.d/postgresql start && su postgres -c "psql -f /tmp/db.sql" \


### PR DESCRIPTION
Habe einen fixen Tag gesetzt, weil immer die aktuellste metasploit version gezogen wurde. 
Die braucht mittlerweile aber ruby 2.6 und nicht mehr 2.5. 
Alternativen sind also ruby version aktualisieren und pot. beim nächsten Update wieder anpassen, oder: fixen c
ommit wählen.