### PR TITLE
Fixing MLP Result dictionary

### DIFF
--- a/algorithms/decision_engines/mlp.py
+++ b/algorithms/decision_engines/mlp.py
@@ -229,10 +229,15 @@ class MLP(BuildingBlock):
             returns: anomaly score
         """
         input_vector = self.input_vector.get_result(syscall)
-        label = self.output_label.get_result(syscall)
+        
         if input_vector is not None:
-            if input_vector in self._result_dict:
-                return self._result_dict[input_vector]
+            label = self.output_label.get_result(syscall)   
+            label_index = label.index(1)
+            concat_input_output = input_vector + tuple([label_index])
+            
+            
+            if concat_input_output in self._result_dict:
+                return self._result_dict[concat_input_output]
             else:
                 in_tensor = torch.tensor(input_vector, dtype=torch.float32, device=device)
                 
@@ -245,7 +250,7 @@ class MLP(BuildingBlock):
                 except:
                     anomaly_score = 1
 
-                self._result_dict[input_vector] = anomaly_score
+                self._result_dict[concat_input_output] = anomaly_score
                 return anomaly_score
         else:
             return None

--- a/algorithms/decision_engines/mlp.py
+++ b/algorithms/decision_engines/mlp.py
@@ -2,8 +2,7 @@ import math
 import torch
 import numpy
 import random
-import collections
-
+import sys
 import numpy as np
 import torch.nn as nn
 
@@ -232,9 +231,12 @@ class MLP(BuildingBlock):
         
         if input_vector is not None:
             label = self.output_label.get_result(syscall)   
-            label_index = label.index(1)
+            try:
+                label_index = label.index(1)    
+            except ValueError:
+                sys.exit('Please use an OneHotEncoding as Output-Label. We can\'t handle other Encodings there right now.')
+                
             concat_input_output = input_vector + tuple([label_index])
-            
             
             if concat_input_output in self._result_dict:
                 return self._result_dict[concat_input_output]


### PR DESCRIPTION
The MLP Result dictionary only used the input_vector to save calculates values until now. Nevertheless, these values are also dependent of the output label. Added this relationship by concatenating these vectors and saved them in the dict.