### PR TITLE
Fix(MLP): More exact addition inhibits anomalyscore overflow

### DIFF
--- a/algorithms/decision_engines/mlp.py
+++ b/algorithms/decision_engines/mlp.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from decimal import Decimal
 import math
 import torch
 import numpy
@@ -240,8 +241,7 @@ class MLP(BuildingBlock):
         with torch.no_grad():
             mlp_out = self._model(in_tensor)
         result = 1 - mlp_out[label_index].item()
-        
-        return result
+        return Decimal(f'{result}')
 
     def _calculate(self, syscall: Syscall):
         """ Forwards the anomaly calculation to the LRU-Cached implementation


### PR DESCRIPTION
The low precision of float addition allowed the anomaly score to be larger then the maximum possible threshold. For example: 
Window-Size: 4, Threshold: 3.999999999999 -> It was possible to receive anomaly scores like 4.000000001 which resulted in a false positive. 

The return type of the mlp calculation was changed to Decimal. This is another datatype which is handled more exact as floats. Even the initialization with string representation was necessary to receive exact values.