### PR TITLE
added LTTng CTF Recording functionality to LID-DS Framework

### DIFF
--- a/lid_ds/utils/docker_utils.py
+++ b/lid_ds/utils/docker_utils.py
@@ -20,7 +20,7 @@ def get_ip_address(container):
 def get_pid_namespace(container):
     container.reload()
     pid = container.attrs["State"]["Pid"]
-    pid_ns = os.popen(f"lsns -n -t pid -o NS -p {pid}").read()
+    pid_ns = os.popen(f"lsns -n -t pid -o NS -p {pid}").read().strip()
     return pid_ns
 
 

--- a/lid_ds/utils/docker_utils.py
+++ b/lid_ds/utils/docker_utils.py
@@ -1,5 +1,6 @@
 import csv
 import os
+import subprocess
 from datetime import datetime
 from threading import Thread
 
@@ -14,6 +15,13 @@ def get_host_port(container, port, protocol="tcp"):
 def get_ip_address(container):
     container.reload()
     return container.attrs['NetworkSettings']['Networks'][ScenarioEnvironment().network.name]['IPAddress']
+
+
+def get_pid_namespace(container):
+    container.reload()
+    pid = container.attrs["State"]["Pid"]
+    pid_ns = os.popen(f"lsns -n -t pid -o NS -p {pid}").read()
+    return pid_ns
 
 
 def format_command(command):

--- a/scenarios/CVE-2017-7529/main_lttng.py
+++ b/scenarios/CVE-2017-7529/main_lttng.py
@@ -1,0 +1,74 @@
+import random
+import sys
+import urllib.request
+
+from lid_ds.core import Scenario
+from lid_ds.core.collector.json_file_store import JSONFileStorage
+from lid_ds.core.image import StdinCommand, Image, ExecCommand
+from lid_ds.core.objects.victim import RecordingModes
+from lid_ds.sim import Sampler
+from lid_ds.utils.docker_utils import get_ip_address
+
+
+class CVE_2017_7529(Scenario):
+
+    def init_victim(self, container, logger):
+        pass
+
+    def wait_for_availability(self, container):
+        try:
+            victim_ip = get_ip_address(container)
+            url = "http://" + victim_ip
+            print("checking... is victim ready?")
+            with urllib.request.urlopen(url) as response:
+                data = response.read().decode("utf8")
+                if "Take on your biggest projects and goals" in data:
+                    print("is ready...")
+                    return True
+                else:
+                    print("not ready yet...")
+                    return False
+        except Exception as error:
+            print("not ready yet with error: " + str(error))
+            return False
+
+
+if __name__ == '__main__':
+    do_normal = bool(int(sys.argv[1]))
+    recording_time = int(sys.argv[2])
+    do_exploit = int(sys.argv[3])
+    if do_exploit < 1:
+        exploit_time = 0
+    else:
+        exploit_time = random.randint(int(recording_time * .3),
+                                      int(recording_time * .8)) if recording_time != -1 else random.randint(5, 15)
+
+    min_user = 3
+    max_user = 5
+
+    if not do_normal:
+        wait_times = {}
+    elif recording_time == -1:
+        # 1800s = 5hrs -> normal behaviour needs to be generated for a long time until exploit ends
+        wait_times = Sampler("Aug28").ip_timerange_sampling(random.randint(min_user, max_user), 1800)
+    else:
+        wait_times = Sampler("Aug28").ip_timerange_sampling(random.randint(min_user, max_user), recording_time)
+
+    storage_services = [JSONFileStorage()]
+
+    victim = Image("victim_overflow")
+    normal = Image("normal_overflow", command=StdinCommand(""), init_args="-ip ${victim} -v 1")
+    exploit = Image("exploit_overflow", command=ExecCommand("python3 /home/exploit.py -ip ${victim}"))
+
+    overflow_scenario = CVE_2017_7529(
+        victim=victim,
+        normal=normal,
+        exploit=exploit,
+        wait_times=wait_times,
+        warmup_time=3,
+        recording_time=recording_time,
+        storage_services=storage_services,
+        exploit_start_time=exploit_time,
+        recording_mode=RecordingModes.LTTng
+    )
+    overflow_scenario()


### PR DESCRIPTION
Aufzeichnung mit LTTng funtioniert jetzt

Voraussetzung ist aktuelle Installation von LTTng: https://lttng.org/docs/v2.13/#doc-building-from-source

kann getestet werden in Szenario CVE-2017-7529 mit
` sudo python3 main_lttng.py 1 30 1`

Output sind .json und .pcap file im runs ordner und ein gleich benannter Ordner mit den CTF Files. Dieser ist aufgrund der Auführung als root auch nur als solcher zu öffnen. Der Inhalt lässt sich z.b. mit dem Tool Trace Compass betrachten.

Die Berechnung des Angriffszeitpunkts erfolgt über die Aufzeichnung des Netzwerktraffics.
