### PR TITLE
[fix, #420] extensible dependency graph to JSON encoding

### DIFF
--- a/algorithms/building_block.py
+++ b/algorithms/building_block.py
@@ -60,25 +60,25 @@ class BuildingBlock:
 
     def __str__(self) -> str:
         """
-        gives a more or less human readable str representation of this object
-        returns: "Name_of_class(memory_address)"
+        gives a more or less human-readable str representation of this object containing the name and configurations
+        """
+        return str(self.to_dict_repr())
+
+    def to_dict_repr(self):
+        """
+        distilled dictionary representation containing the configurations.
         """
         if len(self.__config) > 0:
-            config = self.__config
-            result = str(
-                {
-                    'name': self.__class__.__name__,
-                    'id': hex(id(self)),
-                    'config': config
-                }
-            )
+            result = {
+                'name': self.__class__.__name__,
+                'id': hex(id(self)),
+                'config': self.__config,
+            }
         else:
-            result = str(
-                {
-                    'name': self.__class__.__name__,
-                    'id': hex(id(self)),
-                }
-            )
+            result = {
+                'name': self.__class__.__name__,
+                'id': hex(id(self)),
+            }
         return result
 
     def __repr__(self):
@@ -95,6 +95,7 @@ class BuildingBlock:
             self.__instance_id = BuildingBlockIDManager().get_id(self)
         return self.__instance_id
 
+    @staticmethod
     def __arguments():
         """Returns tuple containing dictionary of calling function's
         named arguments and a list of calling function's unnamed

--- a/algorithms/util/dependency_graph_encoding.py
+++ b/algorithms/util/dependency_graph_encoding.py
@@ -1,0 +1,79 @@
+"""
+Utility functions for converting an ids dependency graph to a json format
+
+"""
+import json
+from enum import Enum
+
+from networkx import DiGraph
+from networkx.readwrite import json_graph
+
+from algorithms.building_block import BuildingBlock
+
+
+def dependency_graph_to_config_tree(dependency_graph: DiGraph) -> dict:
+    """
+        gives the dependency graph as list of links between ids of building blocks
+        each building block contains its config in another list called node
+
+        returns: dictionary with nodes and links of the config graph
+    """
+
+    # getting the dependency tree
+    graph_dict = json_graph.node_link_data(dependency_graph)
+    json_string = json_encode(graph_dict)
+    json_loaded = json.loads(json_string)
+
+    """
+        reforming dictionary to fit:
+        {
+            nodes: [
+                {node1},
+                {node2},
+                ....
+            ]
+            links: [
+                {
+                    'source': node1['id'],
+                    'target': node2['id]
+            ]
+        }
+    """
+
+    short_links = []
+    for link in json_loaded['links']:
+        short_links.append(
+            {
+                'source': link['source']['id'],
+                'target': link['target']['id'],
+            }
+        )
+
+    nodes = []
+    for node in json_loaded['nodes']:
+        nodes.append(node['id'])
+
+    result = {
+        'nodes': nodes,
+        'links': short_links
+    }
+    return result
+
+
+class BBJsonEncoder(json.JSONEncoder):
+    """
+    Custom JSONEncoder that recognizes BuildingBlocks
+    """
+
+    def default(self, obj):
+        """ handle json encoding of non-primitive BuildingBlock class members"""
+        if isinstance(obj, BuildingBlock):
+            return obj.to_dict_repr()
+        if isinstance(obj, Enum):
+            return str(obj.name)
+        return json.JSONEncoder.default(self, obj)
+
+
+def json_encode(data):
+    """alias for `BBJsonEncoder().encode(data)`"""
+    return BBJsonEncoder().encode(data)


### PR DESCRIPTION
- fixes issues with encoding Enums and BuildingBlocks by implementing a custom JSONEncoder
- can be extended in future by adding edge cases to `BBJsonEncoder().default()`
- dependency graph to config encoding functions is decoupled from the ids class. This for example allows easier mocking of the MongoDB without running the ids.
